### PR TITLE
Fix typo in HCV presence logic

### DIFF
--- a/optimus/project_specific/hcv_target.py
+++ b/optimus/project_specific/hcv_target.py
@@ -18,7 +18,7 @@ def process_hcv_values(quant, unit, presence):
     """
     has_hcv = 'DETECTED'
     no_hcv = 'BLOQ'
-    cannot_determine = 'NOT SPECIFIED'
+    cannot_determine = 'NOT_SPECIFIED'
     states = [has_hcv, no_hcv, cannot_determine]
 
     if presence in states:


### PR DESCRIPTION
Testing
Since there are no unit tests in this project and the change is straight
forward, I ran my changes against the same inputs as production and
found the only differences in outputs were changes from "NOT SPECIFIED"
to "NOT_SPECIFIED".

Fixes #7
Fixes OP-7